### PR TITLE
Cross compile to scala3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         scala:
           - 2.13.14
+          - 3.3.3
 
     steps:
       - uses: actions/checkout@v4

--- a/build.sbt
+++ b/build.sbt
@@ -8,22 +8,23 @@ organizationHomepage := Some(url("https://evolution.com"))
 homepage := Some(url("https://github.com/evolution-gaming/resource-pool"))
 startYear := Some(2023)
 
-crossScalaVersions := Seq("2.13.14")
+crossScalaVersions := Seq("2.13.14", "3.3.3")
 scalaVersion := crossScalaVersions.value.head
+releaseCrossBuild := true
 scalacOptions := Seq(
   "-release:17",
   "-Xsource:3",
-  "-deprecation",
+  "-deprecation"
 )
 autoAPIMappings := true
 versionScheme := Some("early-semver")
 publishTo := Some(Resolver.evolutionReleases) // sbt-release
 versionPolicyIntention := Compatibility.BinaryCompatible // sbt-version-policy
 
-libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full)
+
 libraryDependencies ++= Seq(
   `cats-effect`,
-  scalatest,
+  scalatest
 )
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))

--- a/src/test/scala/com/evolution/resourcepool/ResourcePoolTest.scala
+++ b/src/test/scala/com/evolution/resourcepool/ResourcePoolTest.scala
@@ -13,10 +13,10 @@ import scala.concurrent.duration.*
 import scala.util.control.NoStackTrace
 
 class ResourcePoolTest extends AsyncFunSuite with Matchers {
-
+  type IOResource[+A] = Resource[IO, A]
   test("handle invalid `maxSize`") {
     ()
-      .pure[Resource[IO, *]]
+      .pure[IOResource]
       .toResourcePool(
         maxSize = 1,
         expireAfter = 1.day,
@@ -114,7 +114,7 @@ class ResourcePoolTest extends AsyncFunSuite with Matchers {
   test("fail after being released") {
     val result = for {
       result          <- ()
-        .pure[Resource[IO, *]]
+        .pure[IOResource]
         .toResourcePool(
           maxSize = 2,
           expireAfter = 1.day)
@@ -433,7 +433,7 @@ class ResourcePoolTest extends AsyncFunSuite with Matchers {
     val result = for {
       deferred0 <- Deferred[IO, Unit].toResource
       pool      <- ()
-        .pure[Resource[IO, *]]
+        .pure[IOResource]
         .toResourcePool(
           maxSize = 1,
           expireAfter = 1.day)
@@ -469,7 +469,7 @@ class ResourcePoolTest extends AsyncFunSuite with Matchers {
     val result = for {
       deferred0 <- Deferred[IO, Unit].toResource
       pool      <- ()
-        .pure[Resource[IO, *]]
+        .pure[IOResource]
         .toResourcePool(
           maxSize = 1,
           expireAfter = 1.day)
@@ -633,7 +633,7 @@ class ResourcePoolTest extends AsyncFunSuite with Matchers {
   test("discard tasks on release") {
     val result = for {
       result   <- ()
-        .pure[Resource[IO, *]]
+        .pure[IOResource]
         .toResourcePool(
           maxSize = 1,
           expireAfter = 1.day,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.5-SNAPSHOT"
+ThisBuild / version := "2.0.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.1-SNAPSHOT"
+ThisBuild / version := "2.0.0"


### PR DESCRIPTION
This MR adds cross-compilation to scala 3.3.3. 
I also removed kind-projector because a single usage doesn't justify it enough (basically more code to add it than the number of lines it saves)